### PR TITLE
Support zeitwerk

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Redmine plugin enables supply management for issues.
 
 ## Requirements
 
- - Redmine >= 4.0.0
+ - Redmine >= 4.2.0
 
 ## Installation
 
@@ -39,7 +39,7 @@ The GTT Project appreciates any [contributions](https://github.com/gtt-project/.
 
 ## Version History
 
-- 3.0.0 Support Redmine 5.0 and drop Redmine <= 3.4 support
+- 3.0.0 Support Redmine 5.0 and drop Redmine <= 4.1 support
 - 2.1.0 Publish on GitHub
 
 See [all releases](https://github.com/gtt-project/redmine_supply/releases) with release notes.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Redmine plugin enables supply management for issues.
 
 ## Requirements
 
- - Redmine >= 3.4.0
+ - Redmine >= 4.0.0
 
 ## Installation
 
@@ -38,6 +38,9 @@ More information on installing (and uninstalling) Redmine plugins can be found h
 The GTT Project appreciates any [contributions](https://github.com/gtt-project/.github/blob/main/CONTRIBUTING.md)! Feel free to contact us for [reporting problems and support](https://github.com/gtt-project/.github/blob/main/CONTRIBUTING.md).
 
 ## Version History
+
+- 3.0.0 Support Redmine 5.0 and drop Redmine <= 3.4 support
+- 2.1.0 Publish on GitHub
 
 See [all releases](https://github.com/gtt-project/redmine_supply/releases) with release notes.
 

--- a/init.rb
+++ b/init.rb
@@ -18,7 +18,7 @@ Redmine::Plugin.register :redmine_supply do
   description 'Adds configurable supply and resource items to issues'
   version '3.0.0'
 
-  requires_redmine version_or_higher: '4.0.0'
+  requires_redmine version_or_higher: '4.2.0'
 
   settings default: {
     "unit_cf" => "Unit"

--- a/init.rb
+++ b/init.rb
@@ -1,8 +1,13 @@
-require 'redmine'
-
-Rails.configuration.to_prepare do
-  RedmineSupply.setup
-  RedmineResourceManager.setup
+if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
+  Rails.application.config.after_initialize do
+    RedmineSupply.setup
+    RedmineResourceManager.setup
+  end
+else
+  Rails.configuration.to_prepare do
+    RedmineSupply.setup
+    RedmineResourceManager.setup
+  end
 end
 
 Redmine::Plugin.register :redmine_supply do

--- a/init.rb
+++ b/init.rb
@@ -16,9 +16,9 @@ Redmine::Plugin.register :redmine_supply do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_supply'
   description 'Adds configurable supply and resource items to issues'
-  version '2.1.0'
+  version '3.0.0'
 
-  requires_redmine version_or_higher: '3.4.0'
+  requires_redmine version_or_higher: '4.0.0'
 
   settings default: {
     "unit_cf" => "Unit"

--- a/lib/redmine_supply.rb
+++ b/lib/redmine_supply.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'redmine_supply/hooks'
-require 'redmine_supply/view_hooks'
+require File.expand_path('../redmine_supply/hooks', __FILE__)
+require File.expand_path('../redmine_supply/view_hooks', __FILE__)
 
 module RedmineSupply
   def self.setup

--- a/test/integration/supply_items_api_test.rb
+++ b/test/integration/supply_items_api_test.rb
@@ -16,14 +16,14 @@ class SupplyItemsApiTest < Redmine::ApiTest::Base
   test "GET /supply_items.xml should return items" do
     get '/projects/ecookbook/supply_items.xml', :headers => credentials('jsmith')
     assert_response :success
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
     assert_select 'supply_items[type=array] supply_item id', text: @item.id.to_s
   end
 
   test "GET /supply_items/:id.xml should return the item" do
     get "/projects/ecookbook/supply_items/#{@item.id}.xml", :headers => credentials('jsmith')
     assert_response :success
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
     assert_select 'supply_item id', :text => @item.id.to_s
     assert_select 'supply_item name', :text => @item.name.to_s
   end
@@ -34,7 +34,7 @@ class SupplyItemsApiTest < Redmine::ApiTest::Base
 
     get "/projects/ecookbook/supply_items/#{@item.id}.xml", :headers => credentials('jsmith')
     assert_response :success
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
     assert_select 'supply_item id', :text => @item.id.to_s
     assert_select 'supply_item name', :text => @item.name.to_s
   end
@@ -46,7 +46,7 @@ class SupplyItemsApiTest < Redmine::ApiTest::Base
         headers: credentials('jsmith')
     end
     assert_response :created
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
 
     item = SupplyItem.order(:created_at).last
     assert_equal @project, item.project
@@ -63,7 +63,7 @@ class SupplyItemsApiTest < Redmine::ApiTest::Base
         :headers => credentials('jsmith')
     end
     assert_response :unprocessable_entity
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
 
     assert_select 'errors error', :text => "Unit cannot be blank"
   end
@@ -89,7 +89,7 @@ class SupplyItemsApiTest < Redmine::ApiTest::Base
         :headers => credentials('jsmith')
     end
     assert_response :unprocessable_entity
-    assert_equal 'application/xml', @response.content_type
+    assert_equal 'application/xml', @response.media_type
 
     assert_select 'errors error', :text => "Name cannot be blank"
   end

--- a/test/unit/issue_resource_item_test.rb
+++ b/test/unit/issue_resource_item_test.rb
@@ -50,7 +50,7 @@ class IssueResourceItemTest < ActiveSupport::TestCase
     i.reload
     assert i.resource_items.one?
 
-    i.update_attributes issue_resource_items_attributes: [
+    i.update issue_resource_items_attributes: [
       { id: i.issue_resource_items.first.id, _destroy: '1'}
     ]
 


### PR DESCRIPTION
Supports #4.

Changes proposed in this pull request:
- Support both Redmine 5.0 (zeitwerk) and Redmine 4.x
- Fix test error
- TODO: Remove the following warnings
```
/path/to/redmine/plugins/redmine_supply/lib/redmine_resource_manager/save_resource_category.rb:7: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/redmine/plugins/redmine_supply/lib/redmine_resource_manager/save_resource_category.rb:10: warning: The called method `initialize' is defined here
../path/to/redmine/plugins/redmine_supply/lib/redmine_supply/action.rb:4: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/redmine/plugins/redmine_supply/lib/redmine_supply/save_supply_item.rb:6: warning: The called method `initialize' is defined here
/path/to/redmine/plugins/redmine_supply/lib/redmine_resource_manager/save_resource_item.rb:7: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/redmine/plugins/redmine_supply/lib/redmine_resource_manager/save_resource_item.rb:10: warning: The called method `initialize' is defined here
.................../path/to/redmine/plugins/redmine_supply/lib/redmine_supply/action.rb:4: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to/redmine/plugins/redmine_supply/lib/redmine_supply/update_stock.rb:6: warning: The called method `initialize' is defined here
```

@gtt-project/maintainer
