### PR TITLE
Fixed ActiveRecord::IrreversibleMigration issue when uninstalling plugin

### DIFF
--- a/db/migrate/20181008041500_change_stock_count_to_decimal.rb
+++ b/db/migrate/20181008041500_change_stock_count_to_decimal.rb
@@ -1,8 +1,15 @@
 class ChangeStockCountToDecimal < ActiveRecord::Migration[5.2]
-  def change
+  def up
     change_column :supply_items, :stock, :decimal, default: 0, null: false
     change_column :issue_supply_items, :quantity, :decimal, default: 0, null: false
     change_column :supply_item_journals, :old_stock, :decimal, default: 0, null: false
     change_column :supply_item_journals, :new_stock, :decimal
+  end
+
+  def down
+    change_column :supply_items, :stock, :integer, default: 0, null: false
+    change_column :issue_supply_items, :quantity, :integer, default: 0, null: false
+    change_column :supply_item_journals, :old_stock, :integer, default: 0, null: false
+    change_column :supply_item_journals, :new_stock, :integer
   end
 end

--- a/db/migrate/20190412023433_add_type_to_resource_items.rb
+++ b/db/migrate/20190412023433_add_type_to_resource_items.rb
@@ -1,6 +1,11 @@
 class AddTypeToResourceItems < ActiveRecord::Migration[5.2]
-  def change
+  def up
     add_column :resource_items, :type, :string, null: false, default: 'Asset'
     change_column :resource_items, :type, :string, null: false, default: nil
+  end
+
+  def down
+    change_column :resource_items, :type, :string, null: false, default: 'Asset'
+    remove_column :resource_items, :type, :string, null: false, default: 'Asset'
   end
 end


### PR DESCRIPTION
Fixes #6.

Changes proposed in this pull request:
- Fixed ActiveRecord::IrreversibleMigration issue when uninstalling plugin

I referred the following Japanese article to solve the issue.
- [migrationでrollback可否でchangeかup/downを使い分ける - Qiita](https://qiita.com/koni4k/items/294342048cb6d47bcc3f)

Here is the way to confirm the fix.
```sh
bundle exec rake db:drop
bundle exec rake db:create
bundle exec rake db:migrate
bundle exec rake redmine:plugins:migrate
bundle exec rake redmine:plugins:test RAILS_ENV=test NAME=redmine_supply
bundle exec rake redmine:plugins:migrate VERSION=0 NAME=redmine_supply
```

@gtt-project/maintainer
