### PR TITLE
Removed test warnings

### DIFF
--- a/lib/redmine_resource_manager/save_resource_category.rb
+++ b/lib/redmine_resource_manager/save_resource_category.rb
@@ -3,8 +3,8 @@ module RedmineResourceManager
 
     Result = ImmutableStruct.new :category_saved?, :category
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def initialize(params, category: ResourceCategory.new,

--- a/lib/redmine_resource_manager/save_resource_item.rb
+++ b/lib/redmine_resource_manager/save_resource_item.rb
@@ -3,8 +3,8 @@ module RedmineResourceManager
 
     Result = ImmutableStruct.new :item_saved?, :item
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     def initialize(params, resource_class: nil,

--- a/lib/redmine_supply/action.rb
+++ b/lib/redmine_supply/action.rb
@@ -1,7 +1,7 @@
 module RedmineSupply
   class Action
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
   end
 end

--- a/test/unit/supply_item_test.rb
+++ b/test/unit/supply_item_test.rb
@@ -26,7 +26,7 @@ class SupplyItemTest < ActiveSupport::TestCase
   end
 
   test 'should require project' do
-    r = RedmineSupply::SaveSupplyItem.({name: 'test'})
+    r = RedmineSupply::SaveSupplyItem.({name: 'test'}, user: User.current)
     refute r.supply_item_saved?
     assert r.supply_item.errors[:project]
   end


### PR DESCRIPTION
Changes proposed in this pull request:
- Removed test warnings on Ruby >= 2.7 environment.

@gtt-project/maintainer
