### PR TITLE
Added **kwargs to call methond as keyword arguments

### DIFF
--- a/lib/redmine_supply/record_issue_supply_item_change.rb
+++ b/lib/redmine_supply/record_issue_supply_item_change.rb
@@ -1,8 +1,8 @@
 module RedmineSupply
   class RecordIssueSupplyItemChange
 
-    def self.call(*_)
-      new(*_).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     # change is the numerical change of supply item quantity, i.e. if 5kg of


### PR DESCRIPTION
Fixes possible error on Redmine5.0 + Ruby3.1 environment.

Changes proposed in this pull request:
- Added **kwargs to call methond as keyword arguments

@gtt-project/maintainer
