### PR TITLE
Fix undefined method error when issue's supply item is deleted

### DIFF
--- a/app/helpers/supply_items_helper.rb
+++ b/app/helpers/supply_items_helper.rb
@@ -8,6 +8,9 @@ module SupplyItemsHelper
 
   def issue_supply_item_form_tag(issue_supply_item, label: false, deletable: false)
     supply_item = issue_supply_item.supply_item
+    if supply_item.nil?
+      return
+    end
     id = dom_id supply_item
     content_tag :p, id: "#{id}_wrap", class: 'issue_supply_item_wrap' do
       tags = [

--- a/lib/redmine_supply/issue_supply_items_presenter.rb
+++ b/lib/redmine_supply/issue_supply_items_presenter.rb
@@ -22,6 +22,9 @@ module RedmineSupply
 
     def issue_supply_item_tag(issue_supply_item)
       item = issue_supply_item.supply_item
+      if item.nil?
+        return ""
+      end
       "#{h item.name} (#{h issue_supply_item.quantity} #{h item.unit_name})"
     end
   end


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix undefined method error when issue's supply item is deleted

@gtt-project/maintainer
