### PR TITLE
Fix resource category form checkbox labels

### DIFF
--- a/app/views/resource_categories/_form.html.erb
+++ b/app/views/resource_categories/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="box tabular">
   <p><%= f.text_field :name, required: true, size: 25 %></p>
-  <p><%= f.check_box :for_assets %></p>
-  <p><%= f.check_box :for_humans %></p>
+  <p><%= f.check_box :for_assets, { :label => l(:label_resource_category_for_assets) } %></p>
+  <p><%= f.check_box :for_humans, { :label => l(:label_resource_category_for_humans) } %></p>
 </div>
 


### PR DESCRIPTION
@mopinfish 
Currently, `/projects/(project identifier)/resource_categories/new` view's form checkbox labels are not translated.
![supply-project-setting-resource-categories-new-untranslated](https://github.com/gtt-project/redmine_supply/assets/629923/d2fe3c99-103f-45b8-b83d-dd40ed739dad)

Changes proposed in this pull request:
- Fixes the following untranslated resource category form checkbox labels issue.

@gtt-project/maintainer
