### PR TITLE
Separate supply and resource modules

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,7 +65,8 @@ en:
   label_resource_item_end_date: End date
   field_resource_item_start_date: Start date
   field_resource_item_end_date: End date
-  project_module_supply: Supply and Resource
+  project_module_supply: Supply
+  project_module_resource: Resource
   permission_manage_supply_items: Manage supply items
   permission_view_supply_items: View supply items
   permission_view_issue_supply_items: View issue supply items

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -65,7 +65,8 @@ ja:
   label_resource_item_end_date: 終了日
   field_resource_item_start_date: 開始日
   field_resource_item_end_date: 終了日
-  project_module_supply: 資材・リソース
+  project_module_supply: 資材
+  project_module_resource: リソース
   permission_manage_supply_items: 資材の項目を管理
   permission_view_supply_items: 資材の項目を閲覧
   permission_view_issue_supply_items: チケットの資材項目を閲覧

--- a/db/migrate/20231016203000_migrate_enabled_modules.rb
+++ b/db/migrate/20231016203000_migrate_enabled_modules.rb
@@ -1,0 +1,14 @@
+class MigrateEnabledModules < ActiveRecord::Migration[5.2]
+  def self.up
+    execute <<-SQL
+      INSERT INTO enabled_modules (project_id, name)
+      SELECT project_id, 'resource' AS name FROM enabled_modules
+        WHERE name = 'supply' AND
+              NOT EXISTS (SELECT * FROM enabled_modules WHERE name = 'resource')
+    SQL
+  end
+
+  def self.down
+    execute "DELETE FROM enabled_modules WHERE name = 'resource'"
+  end
+end

--- a/init.rb
+++ b/init.rb
@@ -35,6 +35,9 @@ Redmine::Plugin.register :redmine_supply do
       supply_items: %i( autocomplete )
     }, require: :member
 
+  end
+
+  project_module :resource do
     permission :manage_resource_categories, {
       resource_categories: %i( new edit update create destroy ),
       projects: %i( manage_resource_categories )

--- a/test/integration/asset_resource_items_test.rb
+++ b/test/integration/asset_resource_items_test.rb
@@ -11,7 +11,7 @@ class AssetResourceItemsTest < Redmine::IntegrationTest
 
     @project = Project.find 'ecookbook'
     @project.enabled_modules.create! name: 'issue_tracking'
-    @project.enabled_modules.create! name: 'supply'
+    @project.enabled_modules.create! name: 'resource'
 
     @cat = ResourceCategory.generate! project: @project
   end

--- a/test/integration/human_resource_items_test.rb
+++ b/test/integration/human_resource_items_test.rb
@@ -11,7 +11,7 @@ class HumanResourceItemsTest < Redmine::IntegrationTest
 
     @project = Project.find 'ecookbook'
     @project.enabled_modules.create! name: 'issue_tracking'
-    @project.enabled_modules.create! name: 'supply'
+    @project.enabled_modules.create! name: 'resource'
 
     @cat = ResourceCategory.generate! project: @project
   end

--- a/test/integration/issue_resource_items_test.rb
+++ b/test/integration/issue_resource_items_test.rb
@@ -19,7 +19,7 @@ class IssueResourceItemsTest < Redmine::IntegrationTest
     User.current = nil
 
     @project = Project.find 'ecookbook'
-    @project.enabled_modules.create! name: 'supply'
+    @project.enabled_modules.create! name: 'resource'
 
     @cat = ResourceCategory.generate! name: "Car", project: @project
     @item = Asset.create! project: @project, category: @cat, name: 'RCM 429'

--- a/test/integration/resource_categories_test.rb
+++ b/test/integration/resource_categories_test.rb
@@ -11,7 +11,7 @@ class ResourceCategoriesTest < Redmine::IntegrationTest
 
     @project = Project.find 'ecookbook'
     @project.enabled_modules.create! name: 'issue_tracking'
-    @project.enabled_modules.create! name: 'supply'
+    @project.enabled_modules.create! name: 'resource'
   end
 
   def test_resource_categories_require_permission

--- a/test/unit/issue_resource_item_test.rb
+++ b/test/unit/issue_resource_item_test.rb
@@ -19,7 +19,7 @@ class IssueResourceItemTest < ActiveSupport::TestCase
     Role.anonymous.add_permission! :manage_issue_resources
 
     @project = Project.find 'ecookbook'
-    @project.enabled_modules.create! name: 'supply'
+    @project.enabled_modules.create! name: 'resource'
 
     @cat = ResourceCategory.generate! project: @project, name: 'Car'
     @item = Asset.create! project: @project, category: @cat, name: 'RCM 429'


### PR DESCRIPTION
Changes proposed in this pull request:
* Separate supply and resource modules
  * Before:
    * ![separate-modules-before](https://github.com/gtt-project/redmine_supply/assets/629923/6449bf34-cb63-48cd-931d-2e0c678d08df)
  * After:
    * ![separate-modules-after](https://github.com/gtt-project/redmine_supply/assets/629923/3f543ce7-b13a-47f1-8f33-0709c09dfaf5)

TODO:
- [x] Migrate (separate) existence settings

@gtt-project/maintainer
