### PR TITLE
Support active flag to filter supply/resource items

### DIFF
--- a/app/controllers/resource_items_controller.rb
+++ b/app/controllers/resource_items_controller.rb
@@ -103,7 +103,7 @@ class ResourceItemsController < ApplicationController
 
   def resource_item_params
     if parameters = params[:human] || params[:asset]
-      parameters.permit :name, :category_id, :start_date, :end_date, :position
+      parameters.permit :name, :category_id, :start_date, :end_date, :position, :active
     end
   end
 

--- a/app/controllers/supply_items_controller.rb
+++ b/app/controllers/supply_items_controller.rb
@@ -155,7 +155,7 @@ class SupplyItemsController < ApplicationController
 
   def permitted_supply_item_parameters
     cf_ids = [RedmineSupply.unit_cf&.id].compact.map(&:to_s)
-    [:name, :description, custom_field_values: cf_ids]
+    [:name, :description, :active, custom_field_values: cf_ids]
   end
 
 end

--- a/app/models/resource_item.rb
+++ b/app/models/resource_item.rb
@@ -15,6 +15,7 @@ class ResourceItem < (defined?(ApplicationRecord) == 'constant' ? ApplicationRec
 
   acts_as_positioned :scope => [:project_id, :type]
   scope :sorted, ->{ order :position }
+  scope :active, ->{ where(:active => true) }
   scope :humans, ->{ where type: 'Human' }
   scope :assets, ->{ where type: 'Asset' }
   scope :filter_by_date, ->(date = Date.today){
@@ -28,5 +29,8 @@ class ResourceItem < (defined?(ApplicationRecord) == 'constant' ? ApplicationRec
       all
     end
   }
-end
 
+  def css_classes
+    "resource_item " + (active ? "active" : "inactive")
+  end
+end

--- a/app/models/supply_item.rb
+++ b/app/models/supply_item.rb
@@ -13,7 +13,8 @@ class SupplyItem < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecor
                                  scope: :project_id }
   validates :stock, presence: true, numericality: true
 
-  scope :sorted, ->{ order name: :asc}
+  scope :sorted, ->{ order name: :asc }
+  scope :active, ->{ where(:active => true) }
 
   acts_as_customizable
 
@@ -55,4 +56,7 @@ class SupplyItem < (defined?(ApplicationRecord) == 'constant' ? ApplicationRecor
     end
   end
 
+  def css_classes
+    "supply_item " + (active ? "active" : "inactive")
+  end
 end

--- a/app/views/asset_resource_items/index.html.erb
+++ b/app/views/asset_resource_items/index.html.erb
@@ -22,7 +22,7 @@
     </thead>
     <tbody>
       <% for i in @resource_items %>
-        <tr>
+        <tr class="<%= i.css_classes %>">
           <% if categories_present %>
           <td class="category"><%= i.category&.name %>
           <% end %>

--- a/app/views/human_resource_items/index.html.erb
+++ b/app/views/human_resource_items/index.html.erb
@@ -22,7 +22,7 @@
     </thead>
     <tbody>
       <% for i in @resource_items %>
-        <tr>
+        <tr class="<%= i.css_classes %>">
           <% if categories_present %>
           <td class="category"><%= i.category&.name %>
           <% end %>

--- a/app/views/resource_items/_form.html.erb
+++ b/app/views/resource_items/_form.html.erb
@@ -7,6 +7,5 @@
   <% if categories.any? %>
     <p><%= f.select :category_id, categories.sorted.map{|c|[c.name, c.id]}, label: l(:field_resource_category), include_blank: true %></p>
   <% end %>
+  <p><%= f.check_box :active %></p>
 </div>
-
-

--- a/app/views/supply_items/_form.html.erb
+++ b/app/views/supply_items/_form.html.erb
@@ -11,6 +11,7 @@
     <p><%= custom_field_tag_with_label :supply_item, value %></p>
   <% end %>
   <p><%= f.text_area :description, label: l(:field_supply_item_description), rows: 10 %></p>
+  <p><%= f.check_box :active %></p>
 </div>
 
 <%= wikitoolbar_for 'supply_item_description' %>

--- a/app/views/supply_items/_supply_item.html.erb
+++ b/app/views/supply_items/_supply_item.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr class="<%= supply_item.css_classes %>">
   <td class="name"><%= link_to supply_item.name, edit_project_supply_item_path(supply_item.project, supply_item) %></td>
   <td><%= supply_item.stock_text %></td>
   <td class="description"><div><%= textilizable supply_item.description %></div></td>

--- a/assets/stylesheets/supply.css
+++ b/assets/stylesheets/supply.css
@@ -7,12 +7,18 @@ table.list.issues td.issue_asset_resource_item_names {
   white-space: normal;
 }
 
+tr.resource_item.inactive { color: #aaa; }
+tr.resource_item.inactive a { color: #aaa; }
+
 table.list.supply_items tbody td.name,
 table.list.supply_items tbody td.description,
 table.list.supply_item_journals tbody td.name,
 table.list.resource_items tbody td.name {
   text-align: left;
 }
+
+tr.supply_item.inactive { color: #aaa; }
+tr.supply_item.inactive a { color: #aaa; }
 
 /* Supply item history */
 

--- a/db/migrate/20240516070501_add_active_fields_to_items.rb
+++ b/db/migrate/20240516070501_add_active_fields_to_items.rb
@@ -1,0 +1,11 @@
+class AddActiveFieldsToItems < ActiveRecord::Migration[5.2]
+  def self.up
+    add_column :supply_items, :active, :boolean, :default => true, :null => false
+    add_column :resource_items, :active, :boolean, :default => true, :null => false
+  end
+
+  def self.down
+    remove_column :supply_items, :active
+    remove_column :resource_items, :active
+  end
+end

--- a/lib/redmine_resource_manager/resource_items_query.rb
+++ b/lib/redmine_resource_manager/resource_items_query.rb
@@ -22,7 +22,7 @@ module RedmineResourceManager
     private
 
     def all
-      all = @resource_class.where(project_id: @project.id)
+      all = @resource_class.where(project_id: @project.id).where(active: true)
       all = all.where(category_id: @category_id) if @category_id
       all = all.filter_by_date if @filter_by_date
       all = all.like @query if @query

--- a/lib/redmine_supply/supply_items_query.rb
+++ b/lib/redmine_supply/supply_items_query.rb
@@ -23,7 +23,7 @@ module RedmineSupply
     private
 
     def all
-      all = @project.supply_items
+      all = @project.supply_items.active
       all = all.like @query if @query
       all
     end


### PR DESCRIPTION
Closes #18.

Changes proposed in this pull request:
- [x] Add `active (boolean)` flag to supply/resource items
- [x] Filter out inactive supply/resource items in issues new items dialog
- [ ] Add `description` attribute to resource item like supply item
- [ ] Add tests

@gtt-project/maintainer
