### PR TITLE
Replace removed jQuery api '.size()' to '.length'

### DIFF
--- a/app/views/issue_resource_items/create.js.erb
+++ b/app/views/issue_resource_items/create.js.erb
@@ -1,7 +1,7 @@
 var wrapper = $('#<%= @issue_resource_items.first.resource_item.class.name.underscore %>_resource_item_list');
 <% @issue_resource_items.each do |item| %>
   var i = $('#<%= j dom_id item.resource_item %>');
-  if(i.size() == 0){
+  if(i.length == 0){
     wrapper.append('<%= j issue_resource_item_form_tag item %>');
   }
 <% end %>

--- a/app/views/issue_supply_items/create.js.erb
+++ b/app/views/issue_supply_items/create.js.erb
@@ -1,6 +1,6 @@
 <% @issue_supply_items.each do |i| %>
   var wrap = $("#issue-form #<%= dom_id i.supply_item %>_wrap");
-  if (wrap.size() > 0) {
+  if (wrap.length > 0) {
     var quantity = wrap.find('input').val();
     if (quantity) {
       quantity = parseFloat(quantity);


### PR DESCRIPTION
Fixes removed deprecated jQuery API (`.size()`) error after Redmine 5.0.
* [Feature #34337: Remove jQuery Migrate - Redmine](https://www.redmine.org/issues/34337)

Changes proposed in this pull request:
- Replace removed jQuery API '.size()` to `.length`.

@mopinfish (CC: @dkastl)
Target branch is `main`, because `next` branch includes upcoming disabling supply/resource item deletion.
And I will create similar PRs to Privacy and TextBlocks plugins.