### PR TITLE
Supporting Redmine 6.0 (without SVG icon) and drop Redmine <= 5.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         ruby_version: ['3.1', '3.2', '3.3']
         db: ['postgres:14', 'sqlite3']
         exclude:
+          - redmine_version: 5.1-stable
+            ruby_version: '3.3'
           - redmine_version: master
             ruby_version: '3.1'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,97 +17,32 @@ on:
 jobs:
   test:
     name: redmine:${{ matrix.redmine_version }} ruby:${{ matrix.ruby_version }} db:${{ matrix.db }}
-    runs-on: ubuntu-22.04
-
-    container:
-      image: ruby:${{ matrix.ruby_version }}-bullseye
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
       matrix:
-        redmine_version: [4.2-stable, 5.0-stable, 5.1-stable, master]
-        ruby_version: ['2.7', '3.0', '3.1', '3.2']
-        db: [postgres, sqlite]
-        # # System test takes 2~3 times longer, so limit to specific matrix combinations
-        # # See: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        # include:
-        #   - system_test: true
-        #     redmine_version: 5.1-stable
-        #     ruby_version: '3.2'
-        #     db: postgres
+        redmine_version: [5.1-stable, 6.0-stable, master]
+        ruby_version: ['3.1', '3.2', '3.3']
+        db: ['postgres:14', 'sqlite3']
         exclude:
-          - redmine_version: 4.2-stable
-            ruby_version: '3.0'
-          - redmine_version: 4.2-stable
-            ruby_version: '3.1'
-          - redmine_version: 4.2-stable
-            ruby_version: '3.2'
-          - redmine_version: 5.0-stable
-            ruby_version: '3.2'
           - redmine_version: master
-            ruby_version: '2.7'
-
-    services:
-      postgres:
-        image: postgres:10 # min
-        # image: postgres:15 # latest
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+            ruby_version: '3.1'
 
     steps:
-      - name: Checkout Redmine
-        uses: actions/checkout@v4
+      - name: Setup Redmine
+        uses: hidakatsuya/action-setup-redmine@v2
         with:
           repository: redmine/redmine
-          ref: ${{ matrix.redmine_version }}
+          version: ${{ matrix.redmine_version }}
+          ruby-version: ${{ matrix.ruby_version }}
+          database: ${{ matrix.db }}
           path: redmine
 
       - name: Checkout Plugin
         uses: actions/checkout@v4
         with:
           path: redmine/plugins/${{ env.PLUGIN_NAME }}
-
-      - name: Update package archives
-        run: apt-get update --yes --quiet
-
-      - name: Install package dependencies
-        run: |
-          if [ ${{ matrix.db }} = "postgres" ]; then
-            apt-get install --yes --quiet postgresql-client
-          fi
-          # For system test
-          if [ ${{ matrix.system_test }} = "true" ]; then
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-            sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
-            apt-get -y update
-            apt-get install -y google-chrome-stable
-          fi
-
-      - name: Prepare Redmine source
-        working-directory: redmine
-        run: |
-          if [ ${{ matrix.db }} = "postgres" ]; then
-            cat <<EOF > config/database.yml
-              test:
-                adapter: postgresql
-                database: redmine
-                host: postgres
-                username: postgres
-                password: postgres
-                encoding: utf8
-          EOF
-          fi
-          if [ ${{ matrix.db }} = "sqlite" ]; then
-            cat <<EOF > config/database.yml
-              test:
-                adapter: sqlite3
-                database: db/redmine.sqlite3
-          EOF
-          fi
 
       - name: Install Ruby dependencies
         working-directory: redmine
@@ -116,16 +51,12 @@ jobs:
           bundle install --jobs=4 --retry=3
 
       - name: Run Redmine rake tasks
-        env:
-          RAILS_ENV: test
         working-directory: redmine
         run: |
           bundle exec rake generate_secret_token
           bundle exec rake db:create db:migrate redmine:plugins:migrate
 
       - name: Zeitwerk check
-        env:
-          RAILS_ENV: test
         working-directory: redmine
         run: |
           if grep -q zeitwerk config/application.rb ; then
@@ -134,36 +65,11 @@ jobs:
         shell: bash
 
       - name: Run plugin tests
-        env:
-          RAILS_ENV: test
-          # For system test in plugin
-          GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
         working-directory: redmine
         run: |
           bundle exec rake redmine:plugins:test:units NAME=${{ env.PLUGIN_NAME }} RUBYOPT="-W0"
-          bundle exec rake redmine:plugins:test:functionals NAME=${{ env.PLUGIN_NAME }} RUBYOPT="-W0"
           bundle exec rake redmine:plugins:test:integration NAME=${{ env.PLUGIN_NAME }} RUBYOPT="-W0"
-          if [ ${{ matrix.system_test }} = "true" ]; then
-            bundle exec rake redmine:plugins:test:system NAME=${{ env.PLUGIN_NAME }} RUBYOPT="-W0"
-          fi
-
-      # - name: Run core tests
-      #   env:
-      #     RAILS_ENV: test
-      #     PARALLEL_WORKERS: 1
-      #   working-directory: redmine
-      #   run: bundle exec rake test
-
-      # - name: Run core system tests
-      #   if: matrix.system_test == true
-      #   env:
-      #     RAILS_ENV: test
-      #     GOOGLE_CHROME_OPTS_ARGS: "headless,disable-gpu,no-sandbox,disable-dev-shm-usage"
-      #   working-directory: redmine
-      #   run: bundle exec rake test:system
 
       - name: Run uninstall test
-        env:
-          RAILS_ENV: test
         working-directory: redmine
         run: bundle exec rake redmine:plugins:migrate NAME=${{ env.PLUGIN_NAME }} VERSION=0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Redmine plugin enables supply management for issues.
 
 ## Requirements
 
- - Redmine >= 4.2.0
+ - Redmine >= 5.1.0
 
 ## Installation
 
@@ -39,6 +39,7 @@ The GTT Project appreciates any [contributions](https://github.com/gtt-project/.
 
 ## Version History
 
+- 4.0.0 Supporting Redmine 6.0 (without SVG icon) and drop Redmine <= 5.0 support
 - 3.0.0 Support Redmine 5.0 and drop Redmine <= 4.1 support
 - 2.1.0 Publish on GitHub
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Redmine Supply plugin
 
+[![CI](https://github.com/gtt-project/redmine_supply/actions/workflows/test.yml/badge.svg)](https://github.com/gtt-project/redmine_supply/actions?query=workflow%3ATest+branch%3Amain)
+
 This Redmine plugin enables supply management for issues.
 
 ## Requirements

--- a/init.rb
+++ b/init.rb
@@ -1,13 +1,6 @@
-if Rails.version > '6.0' && Rails.autoloaders.zeitwerk_enabled?
-  Rails.application.config.after_initialize do
-    RedmineSupply.setup
-    RedmineResourceManager.setup
-  end
-else
-  Rails.configuration.to_prepare do
-    RedmineSupply.setup
-    RedmineResourceManager.setup
-  end
+Rails.application.config.after_initialize do
+  RedmineSupply.setup
+  RedmineResourceManager.setup
 end
 
 Redmine::Plugin.register :redmine_supply do
@@ -16,9 +9,9 @@ Redmine::Plugin.register :redmine_supply do
   author_url 'https://github.com/georepublic'
   url 'https://github.com/gtt-project/redmine_supply'
   description 'Adds configurable supply and resource items to issues'
-  version '3.0.0'
+  version '4.0.0'
 
-  requires_redmine version_or_higher: '4.2.0'
+  requires_redmine version_or_higher: '5.1.0'
 
   settings default: {
     "unit_cf" => "Unit"


### PR DESCRIPTION
Changes proposed in this pull request:
- Supporting Redmine 6.0 (without SVG icon) and drop Redmine <= 5.0 support
- Fix CI error
- Add CI badge

@gtt-project/maintainer
